### PR TITLE
feat(chatbot): add drought wildfire and landslide support

### DIFF
--- a/backend/alertsystem.py
+++ b/backend/alertsystem.py
@@ -556,8 +556,17 @@ def chatbot():
             "Climate change increases the frequency of extreme weather events.",
 
             "rain":
-            "Heavy rainfall may increase flood risks in vulnerable regions."
+            "Heavy rainfall may increase flood risks in vulnerable regions.",
 
+            "drought":
+            "Droughts occur when rainfall is significantly below normal levels. Conserve water and follow local water restrictions.",
+
+            "wildfire":
+            "Wildfires spread rapidly in hot, dry conditions. Follow evacuation orders and avoid smoke exposure.",
+
+            "landslide":
+            "Landslides can occur after heavy rainfall or earthquakes. Avoid steep slopes and follow local warnings."
+        
         }
 
         for key in responses:
@@ -578,7 +587,7 @@ def chatbot():
             "success": True,
 
             "response":
-            "ClimateBot is ready to help with floods, cyclones, heatwaves, and climate safety."
+            "ClimateBot is ready to help with floods, cyclones, heatwaves, droughts, wildfires, landslides, and climate safety."
 
         })
 


### PR DESCRIPTION
**Summary**

This PR expands ClimateBot's disaster-awareness capabilities by adding support for droughts, wildfires, and landslides.

**Changes Made**

* Added drought-related chatbot responses
* Added wildfire-related chatbot responses
* Added landslide-related chatbot responses
* Updated the chatbot help message to include the newly supported disaster categories

**Testing**

Tested locally by:

1. Running the Flask application
2. Accessing the chatbot through the web interface
3. Verifying responses for:

   * drought
   * wildfire
   * landslide

All responses were returned successfully.

**Why**

Climate Shield focuses on climate awareness and disaster preparedness. Adding support for additional climate hazards helps provide users with broader safety guidance and improves the usefulness of ClimateBot.
