### PR TITLE
feat: add clear results functionality to analysis page

### DIFF
--- a/Frontend/Analysis/analysis.css
+++ b/Frontend/Analysis/analysis.css
@@ -874,3 +874,18 @@ button:hover {
         width: calc(100vw - 20px);
     }
 }
+.button-group {
+    display: flex;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.clear-btn {
+    background: rgba(239, 68, 68, 0.15);
+    border: 1px solid rgba(239, 68, 68, 0.35);
+    color: #fecaca;
+}
+
+.clear-btn:hover {
+    background: rgba(239, 68, 68, 0.25);
+}

--- a/Frontend/Analysis/analysis.html
+++ b/Frontend/Analysis/analysis.html
@@ -132,8 +132,17 @@
                         </div>
                     </div>
 
-                    <button onclick="getWeatherData()">Analyze Climate Risk</button>
+                   <div class="button-group">
 
+    <button id="analyze-btn" onclick="getWeatherData()">
+        Analyze Climate Risk
+    </button>
+
+    <button class="clear-btn" onclick="clearResults()">
+        Clear All
+    </button>
+
+</div>
                     <div id="loading" class="loading hidden">
                         Analyzing live weather data...
                     </div>

--- a/Frontend/Analysis/analysis.js
+++ b/Frontend/Analysis/analysis.js
@@ -9,7 +9,7 @@ const API_URL =
         : window.location.origin + "/weather";
 
 async function getWeatherData() {
-
+    
     const city = document.getElementById('city').value.trim();
 
     const state = document.getElementById('state').value.trim();
@@ -29,6 +29,7 @@ async function getWeatherData() {
     const resultSummary = document.getElementById('result-summary');
 
     const statusPill = document.getElementById('status-pill');
+    const analyzeBtn = document.getElementById('analyze-btn');
 
     const showMessage = (message, tone) => {
 
@@ -69,6 +70,9 @@ async function getWeatherData() {
     }
 
     loading.classList.remove('hidden');
+    analyzeBtn.disabled = true;
+    analyzeBtn.textContent = 'Analyzing...';
+
 
     hideMessage();
 
@@ -98,9 +102,13 @@ async function getWeatherData() {
             })
         });
 
-        const data = await response.json();
+        
+
+const data = await response.json();
 
         loading.classList.add('hidden');
+        analyzeBtn.disabled = false;
+        analyzeBtn.innerText = 'Analyze Climate Risk';
 
         if (!data.success) {
 
@@ -184,10 +192,26 @@ async function getWeatherData() {
         console.error(error);
 
         loading.classList.add('hidden');
+        analyzeBtn.disabled = false;
+       analyzeBtn.textContent = 'Analyze Climate Risk';
 
         showMessage(
             'Backend server is not running.',
             'is-error'
         );
     }
+}
+function clearResults() {
+
+    document.getElementById('city').value = '';
+
+    document.getElementById('state').value = '';
+
+    document.getElementById('country').value = '';
+
+    document.getElementById('results').classList.add('hidden');
+
+    document.getElementById('alert-box').classList.add('hidden');
+
+    document.getElementById('message-box').classList.add('hidden');
 }

--- a/Frontend/Analysis/analysis.js
+++ b/Frontend/Analysis/analysis.js
@@ -365,10 +365,7 @@ function clearResults() {
 
     document.getElementById('message-box').classList.add('hidden');
 }
-        showMessage('Backend server is not running or failed to respond.', 'is-error');
-    }
-}
-
+       
 // Handle alert subscription simulation
 document.addEventListener('DOMContentLoaded', () => {
     const subForm = document.getElementById('subscribe-form');

--- a/Frontend/style.css
+++ b/Frontend/style.css
@@ -761,10 +761,32 @@ button:hover {
         padding: 18px;
         border-radius: 20px;
     }
+    .navbar {
+    align-items: flex-start;
+}
 
     .nav-links {
-        gap: 12px;
-    }
+    gap: 8px;
+    font-size: 0.95rem;
+}
+    .nav-links {
+    gap: 10px;
+    justify-content: flex-start;
+}
+.navbar {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.nav-links {
+    width: 100%;
+    justify-content: flex-start;
+}
+
+.nav-cta {
+    width: 100%;
+    text-align: center;
+}
 
     .hero-copy {
         padding: 12px 0 0;
@@ -797,16 +819,16 @@ button:hover {
     }
 
     .chatbot-toggle {
-        right: 12px;
-        bottom: 12px;
+        right: 18px;
+        bottom: 18px;
         width: 46px;
         height: 46px;
         font-size: 1.2rem;
     }
 
     .chatbot-panel {
-        right: 10px;
-        bottom: 60px;
+        right: 18px;
+        bottom: 78px;
         width: calc(100vw - 20px);
     }
 }

--- a/Frontend/style.css
+++ b/Frontend/style.css
@@ -734,35 +734,6 @@ body {
     .stat-block strong {
         font-size: 1.2rem;
     }
-    .navbar {
-    align-items: flex-start;
-}
-
-    .nav-links {
-    gap: 8px;
-    font-size: 0.95rem;
-}
-    .nav-links {
-    gap: 10px;
-    justify-content: flex-start;
-}
-.navbar {
-    flex-direction: column;
-    align-items: flex-start;
-}
-
-.nav-links {
-    width: 100%;
-    justify-content: flex-start;
-}
-
-.nav-cta {
-    width: 100%;
-    text-align: center;
-}
-
-    .hero-copy {
-        padding: 12px 0 0;
     
     .steps-card {
         padding: 1.2rem;
@@ -806,19 +777,6 @@ body {
         flex-direction: column;
         width: 100%;
     }
-
-    .chatbot-toggle {
-        right: 18px;
-        bottom: 18px;
-        width: 46px;
-        height: 46px;
-        font-size: 1.2rem;
-    }
-
-    .chatbot-panel {
-        right: 18px;
-        bottom: 78px;
-        width: calc(100vw - 20px);
     
     .btn-primary, .btn-secondary {
         text-align: center;


### PR DESCRIPTION
## Description
Added a "Clear Results" button to the Climate Risk Analyzer page.

### Changes Made
- Added a Clear Results button next to the Analyze Climate Risk button.
- Clears all input fields (City, State, Country).
- Hides the results card.
- Removes alerts and messages.
- Resets the analysis page to its initial state.

### Issue Fixed
Closes #46