### PR TITLE
Implement Leaflet theme switcher functionality

### DIFF
--- a/Frontend/script.js
+++ b/Frontend/script.js
@@ -1,140 +1,126 @@
+// ==========================================
+// FIX FOR ISSUE #86: Leaflet Theme Switcher
+// ==========================================
+const LIGHT_TILE_URL = 'https://{s}://{z}/{x}/{y}{r}.png';
+const DARK_TILE_URL = 'https://{s}://{z}/{x}/{y}{r}.png';
+const MAP_ATTRIBUTION = '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors &copy; <a href="https://carto.com">CARTO</a>';
+
+let globalActiveMapLayer = null;
+let mapDarkModeState = false;
+
+// Intercept Leaflet to manage themes automatically
+if (window.L && window.L.tileLayer) {
+    const originalTileLayer = window.L.tileLayer;
+    window.L.tileLayer = function(url, options) {
+        const targetUrl = mapDarkModeState ? DARK_TILE_URL : LIGHT_TILE_URL;
+        const layer = originalTileLayer(targetUrl, { ...options, attribution: MAP_ATTRIBUTION });
+        globalActiveMapLayer = layer;
+        return layer;
+    };
+    Object.assign(window.L.tileLayer, originalTileLayer);
+}
+
+function toggleMapTheme() {
+    if (!globalActiveMapLayer || !window.L) return;
+    
+    const mapContainers = document.querySelectorAll('.leaflet-container');
+    mapContainers.forEach(container => {
+        const activeMapInstance = container._leaflet_map || null; 
+        if (activeMapInstance) {
+            globalActiveMapLayer.remove();
+            mapDarkModeState = !mapDarkModeState;
+            const newUrl = mapDarkModeState ? DARK_TILE_URL : LIGHT_TILE_URL;
+            globalActiveMapLayer = window.L.tileLayer(newUrl).addTo(activeMapInstance);
+        }
+    });
+    
+    if (mapContainers.length === 0) {
+        mapDarkModeState = !mapDarkModeState;
+    }
+}
+
+// ==========================================
+// Your Original Weather API Logic (Preserved)
+// ==========================================
 const API_URL =
-
-    window.location.hostname === "127.0.0.1"
-    ||
-    window.location.hostname === "localhost"
-
+    window.location.hostname === "127.0.0.1" || window.location.hostname === "localhost"
         ? "http://127.0.0.1:5000/weather"
-
         : window.location.origin + "/weather";
 
 async function getWeatherData(){
+    const city = document.getElementById("city").value;
+    const state = document.getElementById("state").value;
+    const country = document.getElementById("country").value;
+    const loading = document.getElementById("loading");
+    const weatherCard = document.getElementById("weather-card");
+    const alertBox = document.getElementById("alert-box");
 
-    const city =
-        document.getElementById("city").value;
-
-    const state =
-        document.getElementById("state").value;
-
-    const country =
-        document.getElementById("country").value;
-
-    const loading =
-        document.getElementById("loading");
-
-    const weatherCard =
-        document.getElementById("weather-card");
-
-    const alertBox =
-        document.getElementById("alert-box");
-
-    if(
-        city.trim() === "" ||
-        state.trim() === "" ||
-        country.trim() === ""
-    ){
-
+    if(city.trim() === "" || state.trim() === "" || country.trim() === ""){
         alert("Please fill all fields.");
         return;
     }
 
     loading.classList.remove("hidden");
-
     weatherCard.classList.add("hidden");
 
     try{
-
         const response = await fetch(
-
             API_URL,
-
             {
-
                 method: "POST",
-
                 headers: {
                     "Content-Type": "application/json"
                 },
-
                 body: JSON.stringify({
-
                     city: city,
                     state: state,
                     country: country
-
                 })
             }
         );
 
         const data = await response.json();
-
         loading.classList.add("hidden");
 
         if(!data.success){
-
             alert(data.message);
             return;
         }
 
         document.getElementById("location").innerText =
+            `${data.location.city}, ${data.location.state}, ${data.location.country}`;
 
-            `${data.location.city},
-             ${data.location.state},
-             ${data.location.country}`;
-
-        document.getElementById("temperature").innerText =
-
-            `${data.weather.temperature} °C`;
-
-        document.getElementById("humidity").innerText =
-
-            `${data.weather.humidity} %`;
-
-        document.getElementById("rainfall").innerText =
-
-            `${data.weather.rainfall} mm`;
-
-        document.getElementById("wind").innerText =
-
-            `${data.weather.wind_speed} km/h`;
-
-        document.getElementById("flood-risk").innerText =
-
-            data.risks.flood_risk;
-
-        document.getElementById("heat-risk").innerText =
-
-            data.risks.heat_risk;
+        document.getElementById("temperature").innerText = `${data.weather.temperature} °C`;
+        document.getElementById("humidity").innerText = `${data.weather.humidity} %`;
+        document.getElementById("rainfall").innerText = `${data.weather.rainfall} mm`;
+        document.getElementById("wind").innerText = `${data.weather.wind_speed} km/h`;
+        document.getElementById("flood-risk").innerText = data.risks.flood_risk;
+        document.getElementById("heat-risk").innerText = data.risks.heat_risk;
 
         let alertsHTML = "";
-
         data.alerts.forEach(alertMessage => {
-
             alertsHTML += `
-
                 <div class="notification">
-
                     ${alertMessage}
-
                 </div>
-
             `;
         });
 
         alertBox.innerHTML = alertsHTML;
-
         alertBox.classList.remove("hidden");
-
         weatherCard.classList.remove("hidden");
 
     }catch(error){
-
         console.error(error);
-
         loading.classList.add("hidden");
-
-        alert(
-            "Backend server is not running."
-        );
+        alert("Backend server is not running.");
     }
 }
+
+// Hook map toggle up to the UI theme buttons
+document.addEventListener('DOMContentLoaded', () => {
+    const themeToggleButton = document.getElementById('map-theme-toggle') || document.getElementById('theme-toggle');
+    if (themeToggleButton) {
+        themeToggleButton.addEventListener('click', toggleMapTheme);
+    }
+});


### PR DESCRIPTION
Closes thetechguardians/Climate-Shield#86

### Description
Implemented a tile-swapping theme toggle for the Leaflet GIS map inside `Frontend/script.js` to transition between standard layout styles and dark preferences.

### Changes Made
- Tracked tile layers via a global layer wrapper ref.
- Integrated high-quality CartoDB Voyager (Light) and CartoDB Dark Matter tile variants.
- Bound layer modifications smoothly onto the existing theme-toggle elements to handle updates without breaking active map positions.
