### PR TITLE
fix: add response.ok HTTP error validation to fetch calls (closes #96)

### DIFF
--- a/Frontend/Analysis/analysis.js
+++ b/Frontend/Analysis/analysis.js
@@ -49,7 +49,6 @@ async function getWeatherData() {
     analyzeBtn.disabled = true;
     analyzeBtn.textContent = 'Analyzing...';
 
-
     hideMessage();
     results.classList.add('hidden');
     results.classList.remove('is-visible');
@@ -64,6 +63,10 @@ async function getWeatherData() {
             },
             body: JSON.stringify({ city, state, country })
         });
+
+        if (!response.ok) {
+            throw new Error(`Server error: ${response.status} ${response.statusText}`);
+        }
 
         const data = await response.json();
         loading.classList.add('hidden');
@@ -343,7 +346,7 @@ async function getWeatherData() {
         console.error(error);
         loading.classList.add('hidden');
         analyzeBtn.disabled = false;
-       analyzeBtn.textContent = 'Analyze Climate Risk';
+        analyzeBtn.textContent = 'Analyze Climate Risk';
 
         showMessage(
             'Backend server is not running.',
@@ -351,21 +354,16 @@ async function getWeatherData() {
         );
     }
 }
+
 function clearResults() {
-
     document.getElementById('city').value = '';
-
     document.getElementById('state').value = '';
-
     document.getElementById('country').value = '';
-
     document.getElementById('results').classList.add('hidden');
-
     document.getElementById('alert-box').classList.add('hidden');
-
     document.getElementById('message-box').classList.add('hidden');
 }
-       
+
 // Handle alert subscription simulation
 document.addEventListener('DOMContentLoaded', () => {
     const subForm = document.getElementById('subscribe-form');
@@ -375,7 +373,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const successMsg = document.getElementById('subscribe-success');
             successMsg.classList.remove('hidden');
             document.getElementById('subscribe-email').value = '';
-            
+
             // Add a entry to logs
             const dispatchLogsBox = document.getElementById('dispatch-logs-box');
             if (dispatchLogsBox) {
@@ -386,7 +384,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 dispatchLogsBox.appendChild(entry);
                 dispatchLogsBox.scrollTop = dispatchLogsBox.scrollHeight;
             }
-            
+
             setTimeout(() => {
                 successMsg.classList.add('hidden');
             }, 4000);

--- a/Frontend/script.js
+++ b/Frontend/script.js
@@ -61,6 +61,10 @@ async function getWeatherData(){
             }
         );
 
+        if (!response.ok) {
+            throw new Error(`Server error: ${response.status} ${response.statusText}`);
+        }
+
         const data = await response.json();
         loading.classList.add("hidden");
 


### PR DESCRIPTION
## 🐛 Fix: Missing HTTP Error Validation in Core Fetch Interface

Closes #96

---

### 📌 Problem

The `fetch()` calls in `Frontend/script.js` and `Frontend/Analysis/analysis.js` were calling `response.json()` directly without checking if the HTTP response was successful. This meant that server errors like `404 Not Found` or `500 Internal Server Error` were silently parsed as JSON, causing:
- Uncaught data-binding failures in the console
- Loading spinners stuck indefinitely
- No user-facing error feedback

---

### ✅ Fix

Added `response.ok` validation in both fetch chains, right before `response.json()` is invoked:

```js
if (!response.ok) {
    throw new Error(`Server error: ${response.status} ${response.statusText}`);
}
```

When a non-2xx status is returned, the error is thrown and caught by the existing `catch` block, which hides the loading spinner and displays a user-facing error message.

---

### 📂 Files Changed

- `Frontend/script.js`
- `Frontend/Analysis/analysis.js`

---

### 🧪 Testing

- Tested with a valid location → works as expected ✅
- Simulated a `404` response → error message shown, spinner dismissed ✅
- Simulated a `500` response → error message shown, spinner dismissed ✅