### PR TITLE
Add structured bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: "🐛 Bug Report"
+description: File a structured bug report to help us improve
+title: "[BUG]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+  
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Tell us exactly how to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / Screen Recordings
+      description: Drag and drop screenshots or paste video links here to help explain your problem.
+      placeholder: Attach visual evidence if applicable.
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment Info
+      description: Browser, OS version, or package versions used.
+      placeholder: e.g., Chrome 124, Windows 11, Node.js v20
+    validations:
+      required: false


### PR DESCRIPTION
## Description
This PR addresses the issue by converting the standard basic markdown bug template into a structured GitHub Issue Form (`.yml`). This transition configures input forms that validate inputs and strictly enforce required context fields—such as "Steps to Reproduce", "Expected Behavior", and "Screenshots"—before a user can successfully submit an issue.

Closes #88

## Type of Contribution
- [x] Documentation / Repository Maintenance – Updates configuration files and templates
