### PR TITLE
feat: add confidence score and risk level to climate analysis results…

### DIFF
--- a/backend/alertsystem.py
+++ b/backend/alertsystem.py
@@ -368,11 +368,21 @@ def get_weather_insights():
             },
 
             "risks": {
-                "flood_risk": round(flood_risk_metric, 3),
-                "heat_risk": round(heat_risk_metric, 3),
-                "wildfire_risk": round(wildfire_risk_metric, 3),
-                "cyclone_risk": round(cyclone_risk_metric, 3),
-                "drought_risk": round(drought_risk_metric, 3)
+    "flood_risk": round(flood_risk_metric, 3),
+    "flood_risk_confidence": round(flood_risk_metric * 100, 1),
+    "flood_risk_level": "HIGH" if flood_risk_metric >= 0.6 else "MEDIUM" if flood_risk_metric >= 0.3 else "LOW",
+    "heat_risk": round(heat_risk_metric, 3),
+    "heat_risk_confidence": round(heat_risk_metric * 100, 1),
+    "heat_risk_level": "HIGH" if heat_risk_metric >= 0.6 else "MEDIUM" if heat_risk_metric >= 0.3 else "LOW",
+    "wildfire_risk": round(wildfire_risk_metric, 3),
+    "wildfire_risk_confidence": round(wildfire_risk_metric * 100, 1),
+    "wildfire_risk_level": "HIGH" if wildfire_risk_metric >= 0.6 else "MEDIUM" if wildfire_risk_metric >= 0.3 else "LOW",
+    "cyclone_risk": round(cyclone_risk_metric, 3),
+    "cyclone_risk_confidence": round(cyclone_risk_metric * 100, 1),
+    "cyclone_risk_level": "HIGH" if cyclone_risk_metric >= 0.6 else "MEDIUM" if cyclone_risk_metric >= 0.3 else "LOW",
+    "drought_risk": round(drought_risk_metric, 3),
+    "drought_risk_confidence": round(drought_risk_metric * 100, 1),
+"drought_risk_level": "HIGH" if drought_risk_metric >= 0.6 else "MEDIUM" if drought_risk_metric >= 0.3 else "LOW",
             },
 
             "forecast": forecast,


### PR DESCRIPTION
## What this does
Adds confidence score (0-100%) and risk level (HIGH/MEDIUM/LOW) alongside 
each existing risk metric in the /weather API response.

## Related Issue
Closes #115

## Why this matters
The current API returns raw risk metrics (0.0 to 1.0) with no human-readable 
interpretation. Emergency responders and users need to know both HOW likely 
a risk is and HOW severe it is at a glance.

## Changes

### backend/alertsystem.py
Added for each risk type (flood, heat, wildfire, cyclone, drought):
- `*_confidence` — risk metric converted to percentage (0-100%)
- `*_level` — categorical label: HIGH (≥60%), MEDIUM (≥30%), LOW (<30%)

## Before & After

Before:
{
  "flood_risk": 0.72
}

After:
{
  "flood_risk": 0.72,
  "flood_risk_confidence": 72.0,
  "flood_risk_level": "HIGH"
}

## No breaking changes
Existing fields are unchanged — new fields are additive only.