### PR TITLE
ENHANCEMENT: Add human-readable risk labels and descriptions to analysis results (#125)

### DIFF
--- a/Frontend/Analysis/analysis.css
+++ b/Frontend/Analysis/analysis.css
@@ -600,11 +600,16 @@ button:hover {
 
 .risk-card {
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 0;
 }
 
-.risk-card p {
+.risk-card > p:not(.risk-label):not(.risk-description) {
   font-size: 1.8rem;
   font-weight: 800;
+  margin: 0;
 }
 
 .flood {
@@ -1037,8 +1042,8 @@ button:hover {
 /* MULTI-RISK GRID (5 CARDS) */
 .risk-grid-five {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
   margin-bottom: 22px;
 }
 
@@ -1561,4 +1566,58 @@ body.light-mode .message-box.is-success {
     background: #dcfce7;
     border: 2px solid #22c55e;
     color: #166534;
+}
+
+/* Risk label — severity pill */
+.risk-card .risk-label {
+  display: inline-block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 6px 0 4px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  width: auto;
+  max-width: 100%;
+}
+
+.risk-card .risk-label.low {
+  color: #1D9E75;
+  background: rgba(29, 158, 117, 0.12);
+}
+
+.risk-card .risk-label.moderate {
+  color: #EF9F27;
+  background: rgba(239, 159, 39, 0.12);
+}
+
+.risk-card .risk-label.high {
+  color: #E05C1A;
+  background: rgba(224, 92, 26, 0.12);
+}
+
+.risk-card .risk-label.critical {
+  color: #E24B4A;
+  background: rgba(226, 75, 74, 0.14);
+}
+
+/* Risk description — plain-language guidance text */
+.risk-card .risk-description {
+  font-size: 0.78rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.6);
+  margin: 4px 0 0;
+  padding: 0 2px;
+  text-align: center;
+  width: 100%;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: normal;
+}
+
+body.light-mode .risk-card .risk-description {
+  color: rgba(30, 41, 59, 0.72);
 }

--- a/Frontend/Analysis/analysis.html
+++ b/Frontend/Analysis/analysis.html
@@ -221,22 +221,32 @@
                                 <div class="risk-card flood">
                                     <h3>Flood Risk</h3>
                                     <p id="flood-risk"></p>
+                                    <p class="risk-label">--</p>
+                                    <p class="risk-description">--</p>
                                 </div>
                                 <div class="risk-card heat">
                                     <h3>Heat Risk</h3>
                                     <p id="heat-risk"></p>
+                                    <p class="risk-label">--</p>
+                                    <p class="risk-description">--</p>
                                 </div>
                                 <div class="risk-card wildfire">
                                     <h3>Wildfire Risk</h3>
                                     <p id="wildfire-risk"></p>
+                                    <p class="risk-label">--</p>
+                                    <p class="risk-description">--</p>
                                 </div>
                                 <div class="risk-card cyclone">
                                     <h3>Cyclone Risk</h3>
                                     <p id="cyclone-risk"></p>
+                                    <p class="risk-label">--</p>
+                                    <p class="risk-description">--</p>
                                 </div>
                                 <div class="risk-card drought">
                                     <h3>Drought Risk</h3>
                                     <p id="drought-risk"></p>
+                                    <p class="risk-label">--</p>
+                                    <p class="risk-description">--</p>
                                 </div>
                             </div>
                         </div>

--- a/Frontend/Analysis/analysis.js
+++ b/Frontend/Analysis/analysis.js
@@ -12,6 +12,49 @@ let riskChartInstance = null;
 // Expose active location data globally for the chatbot to access
 window.activeClimateReport = null;
 
+const descriptions = {
+  flood: {
+    low:      "No significant flood risk right now. Normal conditions expected — no action needed.",
+    moderate: "Some flood potential exists. Avoid low-lying areas during heavy rain and keep an eye on local alerts.",
+    high:     "Flood risk is elevated. Stay away from rivers, drains, and flood-prone zones. Follow official advisories.",
+    critical: "Dangerous flood conditions. Move to higher ground immediately and contact local emergency services.",
+  },
+  heat: {
+    low:      "Heat levels are comfortable. No heat-related precautions needed at this time.",
+    moderate: "Mild heat stress possible. Stay hydrated, limit outdoor activity during peak afternoon hours.",
+    high:     "High heat risk. Avoid outdoor exertion, drink water frequently, and check on elderly neighbours.",
+    critical: "Extreme heat emergency. Stay indoors in a cool place, call for medical help if you feel unwell.",
+  },
+  wildfire: {
+    low:      "Wildfire conditions are calm. No immediate fire risk in your area.",
+    moderate: "Dry and warm conditions present some fire risk. Avoid open burning and report any smoke immediately.",
+    high:     "Elevated wildfire risk. Do not light fires outdoors. Stay informed and be ready to evacuate if directed.",
+    critical: "Critical wildfire danger. Follow evacuation orders immediately and keep emergency bags ready.",
+  },
+  cyclone: {
+    low:      "No cyclone activity expected. Weather conditions are stable.",
+    moderate: "Low-level cyclone indicators detected. Monitor weather bulletins from your local authority.",
+    high:     "Cyclone risk is significant. Secure loose objects, stock emergency supplies, and plan your evacuation route.",
+    critical: "Severe cyclone warning. Seek sturdy shelter immediately and do not travel until the all-clear is given.",
+  },
+  drought: {
+    low:      "Water supply conditions are normal. No drought stress at this time.",
+    moderate: "Some drought stress is possible. Consider conserving water and monitoring local reservoir advisories.",
+    high:     "Drought conditions are significant. Restrict non-essential water use and follow local water-saving guidelines.",
+    critical: "Severe drought. Water shortages likely. Comply with all rationing measures and store emergency water supplies.",
+  },
+};
+
+function getRiskLevel(score, riskType) {
+  const type = riskType.toLowerCase();
+  const d = descriptions[type] || descriptions.flood;
+
+  if (score <= 0.29) return { label: "Low",      cssClass: "low",      desc: d.low      };
+  if (score <= 0.49) return { label: "Moderate", cssClass: "moderate", desc: d.moderate };
+  if (score <= 0.69) return { label: "High",     cssClass: "high",     desc: d.high     };
+                     return { label: "Critical", cssClass: "critical", desc: d.critical  };
+}
+
 async function getWeatherData() {
   const city = document.getElementById("city").value.trim();
   const state = document.getElementById("state").value.trim();
@@ -93,12 +136,60 @@ async function getWeatherData() {
       `${data.weather.wind_speed} km/h`;
 
     // Risks scores
-    document.getElementById("flood-risk").innerText = data.risks.flood_risk;
-    document.getElementById("heat-risk").innerText = data.risks.heat_risk;
-    document.getElementById("wildfire-risk").innerText =
-      data.risks.wildfire_risk;
-    document.getElementById("cyclone-risk").innerText = data.risks.cyclone_risk;
-    document.getElementById("drought-risk").innerText = data.risks.drought_risk;
+    const floodCard = document.querySelector(".risk-card.flood");
+    const floodScore = data.risks.flood_risk;
+    document.getElementById("flood-risk").innerText = floodScore;
+    let score = floodScore;
+    let card = floodCard;
+    let level = getRiskLevel(score, "flood");
+    let labelEl = card.querySelector(".risk-label");
+    labelEl.textContent = level.label;
+    labelEl.className = "risk-label " + level.cssClass;
+    card.querySelector(".risk-description").textContent = level.desc;
+
+    const heatCard = document.querySelector(".risk-card.heat");
+    const heatScore = data.risks.heat_risk;
+    document.getElementById("heat-risk").innerText = heatScore;
+    score = heatScore;
+    card = heatCard;
+    level = getRiskLevel(score, "heat");
+    labelEl = card.querySelector(".risk-label");
+    labelEl.textContent = level.label;
+    labelEl.className = "risk-label " + level.cssClass;
+    card.querySelector(".risk-description").textContent = level.desc;
+
+    const wildfireCard = document.querySelector(".risk-card.wildfire");
+    const wildfireScore = data.risks.wildfire_risk;
+    document.getElementById("wildfire-risk").innerText = wildfireScore;
+    score = wildfireScore;
+    card = wildfireCard;
+    level = getRiskLevel(score, "wildfire");
+    labelEl = card.querySelector(".risk-label");
+    labelEl.textContent = level.label;
+    labelEl.className = "risk-label " + level.cssClass;
+    card.querySelector(".risk-description").textContent = level.desc;
+
+    const cycloneCard = document.querySelector(".risk-card.cyclone");
+    const cycloneScore = data.risks.cyclone_risk;
+    document.getElementById("cyclone-risk").innerText = cycloneScore;
+    score = cycloneScore;
+    card = cycloneCard;
+    level = getRiskLevel(score, "cyclone");
+    labelEl = card.querySelector(".risk-label");
+    labelEl.textContent = level.label;
+    labelEl.className = "risk-label " + level.cssClass;
+    card.querySelector(".risk-description").textContent = level.desc;
+
+    const droughtCard = document.querySelector(".risk-card.drought");
+    const droughtScore = data.risks.drought_risk;
+    document.getElementById("drought-risk").innerText = droughtScore;
+    score = droughtScore;
+    card = droughtCard;
+    level = getRiskLevel(score, "drought");
+    labelEl = card.querySelector(".risk-label");
+    labelEl.textContent = level.label;
+    labelEl.className = "risk-label " + level.cssClass;
+    card.querySelector(".risk-description").textContent = level.desc;
 
     // Demo indicator
     if (data.demo_mode) {


### PR DESCRIPTION
## Summary
Closes #125

Risk scores like `0.217` or `0.383` were raw decimals with no context — 
a non-technical user (farmer, student, emergency volunteer) couldn't tell 
whether a score meant safety or danger. This PR adds plain-language severity 
labels and actionable descriptions to all 5 risk cards, and fixes a CSS 
cascade bug uncovered during implementation.

---

## What changed

### `Frontend/Analysis/analysis.js`
- Added `descriptions` object with per-risk-type guidance text for all 
  4 severity levels (Low / Moderate / High / Critical) across all 5 risk 
  types: Flood, Heat, Wildfire, Cyclone, Drought
- Added `getRiskLevel(score, riskType)` helper that maps a 0–1 score to 
  a label, CSS class, and plain-language description
- Updated risk card rendering to call `getRiskLevel()` and populate both 
  `.risk-label` and `.risk-description` elements dynamically

### `Frontend/Analysis/analysis.html`
- Added `<p class="risk-label">` and `<p class="risk-description">` 
  placeholder elements inside all 5 risk cards

### `Frontend/Analysis/analysis.css`
- Added `.risk-label` styles with severity colour classes: 
  `.low` (green) / `.moderate` (amber) / `.high` (orange) / `.critical` (red)
- Added `.risk-description` styles for muted, readable guidance text
- **Bug fix:** Scoped the large score style from `.risk-card p` to 
  `.risk-card > p:not(.risk-label):not(.risk-description)` — the blanket 
  selector was applying `1.8rem / font-weight: 800` to label and description 
  paragraphs, causing text to render at heading scale and overflow card bounds
- **Bug fix:** Added `display: flex; flex-direction: column; min-width: 0` 
  to `.risk-card` so content stays contained within column boundaries
- **Bug fix:** Raised grid column `minmax` from `130px` to `200px` so cards 
  wrap to 2–3 per row instead of squeezing all five into a narrow strip

---

## Severity thresholds

| Score | Label | Colour |
|---|---|---|
| 0.00 – 0.29 | Low | Green |
| 0.30 – 0.49 | Moderate | Amber |
| 0.50 – 0.69 | High | Orange |
| 0.70 – 1.00 | Critical | Red |

---

## Screenshots
<img width="1002" height="741" alt="image" src="https://github.com/user-attachments/assets/1ba2b201-915c-414c-8b79-40406440a70f" />


---

## Checklist
- [x] Works for all 5 risk types: Flood, Heat, Wildfire, Cyclone, Drought
- [x] Numeric score still visible (not removed)
- [x] Label is colour-coded by severity
- [x] Description text wraps correctly at all card widths
- [x] No backend changes required
- [x] Hard-refreshed and tested with live analysis