### PR TITLE
Add risk explanations for each day's hazard status.issue #147

### DIFF
--- a/Frontend/Analysis/analysis.css
+++ b/Frontend/Analysis/analysis.css
@@ -1669,3 +1669,17 @@ body.light-theme .search-chip:hover {
   background: #bae6fd;
   color: #0c4a6e;
 }
+.forecast-primary-cause {
+  margin-top: 10px;
+  text-align: center;
+  color: #fbbf24;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.forecast-secondary-cause {
+  margin-top: 4px;
+  text-align: center;
+  color: #fcd34d;
+  font-size: 0.8rem;
+}

--- a/Frontend/Analysis/analysis.js
+++ b/Frontend/Analysis/analysis.js
@@ -1,6 +1,6 @@
 const API_URL =
   window.location.hostname === "127.0.0.1" ||
-  window.location.hostname === "localhost"
+    window.location.hostname === "localhost"
     ? "http://127.0.0.1:5000/weather"
     : window.location.origin + "/weather";
 
@@ -206,22 +206,22 @@ async function getWeatherData() {
     // Store last analysis result so ClimateBot can use it
     window.lastAnalysisContext = {
       location: {
-        city:    city,
-        state:   state,
+        city: city,
+        state: state,
         country: country,
       },
       weather: {
         temperature: data.weather.temperature,
-        humidity:    data.weather.humidity,
-        rainfall:    data.weather.rainfall,
-        wind_speed:  data.weather.wind_speed,
+        humidity: data.weather.humidity,
+        rainfall: data.weather.rainfall,
+        wind_speed: data.weather.wind_speed,
       },
       risks: {
-        flood_risk:    data.risks.flood_risk,
-        heat_risk:     data.risks.heat_risk,
+        flood_risk: data.risks.flood_risk,
+        heat_risk: data.risks.heat_risk,
         wildfire_risk: data.risks.wildfire_risk,
-        cyclone_risk:  data.risks.cyclone_risk,
-        drought_risk:  data.risks.drought_risk,
+        cyclone_risk: data.risks.cyclone_risk,
+        drought_risk: data.risks.drought_risk,
       },
     };
 
@@ -338,19 +338,48 @@ async function getWeatherData() {
       );
       const isDanger = maxDayRisk >= 0.65;
       const alertTag = isDanger ? "⚠️ High Hazard" : "✅ Normal";
+      const riskMap = {
+  Flood: day.risks.flood_risk,
+  Heat: day.risks.heat_risk,
+  Wildfire: day.risks.wildfire_risk,
+  Cyclone: day.risks.cyclone_risk,
+  Drought: day.risks.drought_risk,
+};
+
+const sortedRisks = Object.entries(riskMap)
+  .sort((a, b) => b[1] - a[1]);
+
+const primaryRisk = sortedRisks[0];
+const secondaryRisk = sortedRisks[1];
+
+const primaryCause = primaryRisk[0];
+const primaryScore = primaryRisk[1];
+
 
       const card = document.createElement("div");
       card.className = "forecast-card";
-      card.innerHTML = `
-                <div class="forecast-date">${formattedDate}</div>
-                <div class="forecast-temp">${day.temperature} °C</div>
-                <div class="forecast-details">
-                    <span>💧 Humid: ${day.humidity}%</span>
-                    <span>🌧 Rain: ${day.rainfall} mm</span>
-                    <span>🌪 Wind: ${day.wind_speed} km/h</span>
-                </div>
-                <div class="forecast-risk-indicator ${isDanger ? "has-danger" : ""}">${alertTag}</div>
-            `;
+     card.innerHTML = `
+    <div class="forecast-date">${formattedDate}</div>
+    <div class="forecast-temp">${day.temperature} °C</div>
+
+    <div class="forecast-details">
+        <span>💧 Humid: ${day.humidity}%</span>
+        <span>🌧 Rain: ${day.rainfall} mm</span>
+        <span>🌪 Wind: ${day.wind_speed} km/h</span>
+    </div>
+
+    <div class="forecast-risk-indicator ${isDanger ? "has-danger" : ""}">
+        ${alertTag}
+    </div>
+
+    <div class="forecast-primary-cause">
+        Primary Cause: ${primaryCause} Risk (${primaryScore.toFixed(2)})
+    </div>
+
+    <div class="forecast-secondary-cause">
+        Also: ${secondaryRisk[0]} Risk (${secondaryRisk[1].toFixed(2)})
+    </div>
+`;
       forecastContainer.appendChild(card);
     });
 
@@ -649,7 +678,7 @@ window.useCurrentLocation = async function () {
       try {
         const reverseGeocodeUrl =
           window.location.hostname === "127.0.0.1" ||
-          window.location.hostname === "localhost"
+            window.location.hostname === "localhost"
             ? "http://127.0.0.1:5000/reverse-geocode"
             : window.location.origin + "/reverse-geocode";
 


### PR DESCRIPTION
## Summary

Enhanced the Analysis page forecast cards by adding risk explanations for each day's hazard status.

## Changes Made

* Added **Primary Cause** display for forecast risk cards.
* Added **Secondary Cause** display to provide additional context.
* Calculated the highest and second-highest risk factors from:

  * Flood Risk
  * Heat Risk
  * Wildfire Risk
  * Cyclone Risk
  * Drought Risk
* Added styling for the new risk explanation sections in the forecast cards.
* Improved readability of hazard indicators by showing the reason behind the displayed risk status.

## Example

Before:
<img width="1333" height="675" alt="Screenshot 2026-06-06 124952" src="https://github.com/user-attachments/assets/2352f821-1cb1-41a4-9cb5-6ba27ff03125" />

After:
<img width="1269" height="560" alt="Screenshot 2026-06-06 135752" src="https://github.com/user-attachments/assets/8702c59b-4d80-4ef0-bbbd-ab5598c12c34" />

## Files Modified

* `Frontend/Analysis/analysis.js`
* `Frontend/Analysis/analysis.css`

## Testing

* Verified weather data is fetched successfully from the `/weather` API.
* Confirmed forecast cards render primary and secondary risk causes correctly.
* Confirmed existing hazard calculations and charts remain unaffected.
* issue #147 
