### PR TITLE
fix: move analyzeBtn re-enable to finally block to prevent stuck disa…

### DIFF
--- a/Frontend/Analysis/analysis.js
+++ b/Frontend/Analysis/analysis.js
@@ -100,9 +100,7 @@ async function getWeatherData() {
     return;
   }
 
-  loading.classList.remove("hidden");
-  analyzeBtn.disabled = true;
-  analyzeBtn.textContent = "Analyzing...";
+  loading.classList.add("hidden");
 
   hideMessage();
   results.classList.add("hidden");
@@ -617,13 +615,13 @@ const primaryScore = primaryRisk[1];
     resultSummary.innerText =
       "Live weather and risk analysis generated successfully.";
     statusPill.innerText = "Analysis Complete";
-  } catch (error) {
+} catch (error) {
     console.error(error);
     loading.classList.add("hidden");
+    showMessage("Backend server is not running.", "is-error");
+  } finally {
     analyzeBtn.disabled = false;
     analyzeBtn.textContent = "Analyze Climate Risk";
-
-    showMessage("Backend server is not running.", "is-error");
   }
 }
 


### PR DESCRIPTION
What's the problem?
The Analyze button remained clickable during API calls, allowing multiple duplicate requests to be sent.
What I changed:

Removed analyzeBtn.disabled = false and re-enable logic from inside the try block
Moved button re-enable to a finally block so it always resets whether the request succeeds or fails

Files changed:
Frontend/Analysis/analysis.js