### PR TITLE
chore: add backend package init; add fetch_gis_alert_data helper and …

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,2 @@
+# intentionally left empty — makes backend a package for making
+# it as importable from the outside

--- a/backend/alertsystem.py
+++ b/backend/alertsystem.py
@@ -6,6 +6,37 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+GIS_ALERTS_URL = os.environ.get("GIS_ALERTS_URL", "https://example.com/gis/alerts")
+
+def fetch_gis_alert_data():
+    """
+    Helper used by tests. Calls requests.get so tests can patch requests.get.
+    Returns (data, status_code).
+
+    Behavior expected by tests:
+      - requests.exceptions.ConnectionError -> (None, 503)
+      - requests.exceptions.Timeout         -> (None, 504)
+      - On success: (response.json() or response.text, response.status_code)
+      - On other exceptions: (None, 500)
+    """
+    try:
+        resp = requests.get(GIS_ALERTS_URL, timeout=10)
+        resp.raise_for_status()
+        try:
+            data = resp.json()
+        except ValueError:
+            data = resp.text
+        return data, resp.status_code
+
+    except requests.exceptions.ConnectionError:
+        return None, 503
+
+    except requests.exceptions.Timeout:
+        return None, 504
+
+    except Exception:
+        return None, 500
+    
 from flask import (
     Flask,
     jsonify,

--- a/backend/test_alertsystem.py
+++ b/backend/test_alertsystem.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 from unittest.mock import patch
-from alertsystem import fetch_gis_alert_data
+from backend.alertsystem import fetch_gis_alert_data
 
 @patch('requests.get')
 def test_gis_api_down_returns_503(mock_get):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask-cors
 requests
 gunicorn
 python-dotenv
+pytest


### PR DESCRIPTION
**Short summary**

Added backend/init.py so backend is a Python package.
Added fetch_gis_alert_data helper to backend/alertsystem.py so tests can import it (handles ConnectionError -> 503 and Timeout -> 504).
Added **pytest** to requirements.txt so contributors/CI can run tests.

**What I changed**

backend/init.py (new)
backend/alertsystem.py (added fetch_gis_alert_data helper)
backend/test_alertsystem.py (import updated to from backend.alertsystem import fetch_gis_alert_data)
requirements.txt (added pytest)

**Why**

pytest failed during collection because tests import fetch_gis_alert_data from backend.alertsystem but that symbol didn't exist, and backend wasn't a package due to missing init.py. Adding the helper and package init fixes test collection and makes tests reproducible in contributor environments.

**How to verify locally**

```
Create virtualenv and activate it (if not already)
pip install -r requirements.txt
python -m pytest backend/test_alertsystem.py -q
```

Closes #104