### PR TITLE
Fix location popup initial render (#190)

### DIFF
--- a/Frontend/Analysis/analysis.js
+++ b/Frontend/Analysis/analysis.js
@@ -457,7 +457,9 @@ async function getWeatherData() {
             </div>
         `,
       )
-      .openPopup();
+      mapInstance.once("moveend", () => {
+        mapMarker.openPopup();
+      });
 
     // Render 5-Day Forecast
     const forecastContainer = document.getElementById(


### PR DESCRIPTION
# What changed

Fixed the initial rendering issue of the location popup on the Interactive GIS Climate Map. (#190 )

Previously, the popup was opened immediately using .openPopup() after binding it to the marker. This caused the popup to render with incorrect dimensions and positioning during the initial map load.

The popup is now opened after the map's moveend event:
```js
460 | mapInstance.once("moveend", () => {
461 |   mapMarker.openPopup();
462 | });
```

# Why it was added

The popup was appearing narrow and uncentered when displayed for the first time. Waiting for the map movement to complete before opening the popup ensures that Leaflet calculates the popup size and position correctly on initial render.

This results in the popup being displayed with the correct width and aligned properly with the marker without requiring the user to click the marker again.