### PR TITLE
Fix/ai exit clause

### DIFF
--- a/AI-chatbot/chatbot.py
+++ b/AI-chatbot/chatbot.py
@@ -225,9 +225,9 @@ def generate_response(user_input, context_summary=""):
     # ======================================
     # BASIC CONVERSATION
     # ======================================
-
-    if any(word in user for word in
-           ["hello", "hi", "hey"]):
+    user_words=user.strip.split().lower()
+    hello_keywords=["hello","hi","hey"]
+    if any(keyword in user_words for keyword im hello_keywords) or user.strip in hello_keywords;
 
         return random.choice([
 
@@ -254,6 +254,15 @@ def generate_response(user_input, context_summary=""):
             "Glad I could help.",
             "Stay safe."
         ])
+
+    exit_keywords=["bye","quit","exit","goodbye"]
+    if any(keyword in user_words for keyword in exit_keywords) or user.strip().lower() in exit_keywords:
+        return random.choice([
+            "Goodbye 🌍 Stay safe.",
+            "Take care,"
+        ])
+            
+        
 
     # ======================================
     # CONTEXT MEMORY

--- a/AI-chatbot/chatbot.py
+++ b/AI-chatbot/chatbot.py
@@ -225,9 +225,9 @@ def generate_response(user_input, context_summary=""):
     # ======================================
     # BASIC CONVERSATION
     # ======================================
-    user_words=user.strip.split().lower()
+    user_words=user.strip().split()
     hello_keywords=["hello","hi","hey"]
-    if any(keyword in user_words for keyword im hello_keywords) or user.strip in hello_keywords;
+    if any(keyword in user_words for keyword im hello_keywords) or user.strip in hello_keywords:
 
         return random.choice([
 

--- a/AI-chatbot/chatbot.py
+++ b/AI-chatbot/chatbot.py
@@ -225,9 +225,9 @@ def generate_response(user_input, context_summary=""):
     # ======================================
     # BASIC CONVERSATION
     # ======================================
-    user_words=user.strip().split()
+    user_words=user_input.strip().lower().split()
     hello_keywords=["hello","hi","hey"]
-    if any(keyword in user_words for keyword im hello_keywords) or user.strip in hello_keywords:
+    if any(keyword in hello_keywords for keyword in user_words) or user_input.lower().strip() in hello_keywords:
 
         return random.choice([
 
@@ -236,7 +236,7 @@ def generate_response(user_input, context_summary=""):
             "Greetings from Climate Shield 🌍"
         ])
 
-    if "how are you" in user:
+    if "how are you" in user_words:
 
         return random.choice([
 
@@ -245,7 +245,7 @@ def generate_response(user_input, context_summary=""):
             "All systems operational."
         ])
 
-    if any(word in user for word in
+    if any(word in user_words for word in
            ["thank", "thanks"]):
 
         return random.choice([
@@ -256,7 +256,7 @@ def generate_response(user_input, context_summary=""):
         ])
 
     exit_keywords=["bye","quit","exit","goodbye"]
-    if any(keyword in user_words for keyword in exit_keywords) or user.strip().lower() in exit_keywords:
+    if any(keyword in exit_keywords for keyword in user_words) or user_input.lower().strip() in exit_keywords:
         return random.choice([
             "Goodbye 🌍 Stay safe.",
             "Take care,"


### PR DESCRIPTION
<img width="1600" height="2560" alt="Screenshot_2026-06-13-16-17-59-954_com android chrome" src="https://github.com/user-attachments/assets/aad1bc2a-296c-488b-9edc-82d8c6fa80e9" />

<img width="2560" height="1600" alt="Screenshot_2026-06-13-16-10-02-003_com android chrome" src="https://github.com/user-attachments/assets/cf1778f4-3d02-4155-9ed1-6f2f846897eb" />
What changed?
This pr resolves some logical flaws in basic conversation of AI chatbot.
Why was it changed?
First, when words such "exit" or "quit" were put, the chatbot switched to smart responses because of the absence of proper codeblock.
Second, due to a logical bug, whenever the chatbot detected the string of words such as "hi" or "hello" even as a substring of words like in "highly" it assumed it to be a greeting.
Testing:
The code has been verified.