### PR TITLE
fix: convert dashboard decimal risk scores to percentage formatFix dashboard decimal values to percentage format

### DIFF
--- a/Frontend/Analysis/analysis.js
+++ b/Frontend/Analysis/analysis.js
@@ -1,3 +1,6 @@
+// Isse decimal value percentage mein convert ho jayegi (e.g., 0.936 -> 93.6%)
+const toPercent = (val) => val ? (val * 100).toFixed(1) + '%' : '0%';
+
 const API_URL =
   window.location.hostname === "127.0.0.1" ||
   window.location.hostname === "localhost"


### PR DESCRIPTION
Fixes #225 

- Converted raw decimal values (e.g., 0.936) for drought, flood, and wildfire risks into formatted percentages (e.g., 93.6%) using .toFixed(1).
- Fixed the visual bug on the analysis dashboard cards.
- Closes #210