### PR TITLE
Add scroll to top button on home page

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -458,6 +458,7 @@
         <div id="chatbot-status" class="chatbot-status hidden"></div>
       </section>
     </div>
+    <button id="scrollTopBtn" class="scroll-top-btn" title="Back to Top">↑</button>
 
     <script src="script.js"></script>
     <script src="chatbot.js"></script>

--- a/Frontend/script.js
+++ b/Frontend/script.js
@@ -242,23 +242,24 @@ window.onload = function () {
                 `⚠️ Anomaly: ${a.value}°C (z=${a.zScore.toFixed(2)})`
             ).join("<br>");
 };
+};
 
+// Scroll to Top Button
 const scrollTopBtn = document.getElementById("scrollTopBtn");
 
 if (scrollTopBtn) {
-    window.addEventListener("scroll", () => {
-        if (window.scrollY > 300) {
-            scrollTopBtn.classList.add("show");
-        } else {
-            scrollTopBtn.classList.remove("show");
-        }
-    });
+  window.addEventListener("scroll", () => {
+    if (window.scrollY > 300) {
+      scrollTopBtn.classList.add("show");
+    } else {
+      scrollTopBtn.classList.remove("show");
+    }
+  });
 
-    scrollTopBtn.addEventListener("click", () => {
-        window.scrollTo({
-            top: 0,
-            behavior: "smooth"
-        });
+  scrollTopBtn.addEventListener("click", () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
     });
+  });
 }
-};

--- a/Frontend/style.css
+++ b/Frontend/style.css
@@ -1291,3 +1291,37 @@ body.light-mode .navbar {
 [data-theme="light"] .footer-links a:hover {
   color: #0369a1;
 }
+}
+
+/* Scroll to Top Button */
+#scrollTopBtn,
+.scroll-top-btn {
+  position: fixed;
+  right: 31px;
+  bottom: 96px;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  z-index: 9999;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: white;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(14, 165, 233, 0.35);
+  transition: opacity 0.3s, transform 0.2s;
+}
+
+#scrollTopBtn.show,
+.scroll-top-btn.show {
+  display: flex;
+}
+
+#scrollTopBtn:hover,
+.scroll-top-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(14, 165, 233, 0.45);
+}


### PR DESCRIPTION
## Summary
Added "Move to Top" (scroll-to-top) button to the Home page (index.html) 
to maintain UI/UX consistency with the Analysis page.

## Changes Made
- `Frontend/index.html` — Added `#scrollTopBtn` button element
- `Frontend/style.css` — Added `.scroll-top-btn` styles
- `Frontend/script.js` — Added scroll event listener and smooth scroll logic

## How to Test
1. Open `Frontend/index.html`
2. Scroll down more than 300px
3. Button appears at bottom-right corner
4. Click it and then page smoothly scrolls to top

## Related Issue
Fixes #209 

## Screenshot
<img width="1915" height="905" alt="image" src="https://github.com/user-attachments/assets/4f8126ac-96fd-4cd5-afe9-29b4bb204dd4" />
